### PR TITLE
Minor improvement: Make max_items Option<u16> rather than u8

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -102,7 +102,7 @@ pub struct NestedBlock {
     block: Block,
     nesting_mode: Option<String>,
     min_items: Option<u8>,
-    max_items: Option<u8>,
+    max_items: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -448,11 +448,11 @@ mod test {
     name = "testing"
     version = "0.1.0"
     edition = "2018"
-    
+
     [dependencies]
     serde = { version = "1.0", features = ["derive"] }
     serde_bytes = "0.11"
-    
+
     [workspace]
     "#,
         )


### PR DESCRIPTION
Currently `max_items` is `Option<u8>` which imposes a maximum item count of 255, which is not enough to parse the `aws` provider's schema. 

This change ups that to `u16` (seems big enough to me).